### PR TITLE
Add double slash comments to tokenizer

### DIFF
--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -317,6 +317,10 @@ function tokenizer(input, options = {}) {
 
 					currentToken = ['comment', css.slice(pos, next + 1), pos, next];
 					pos = next;
+				} else if (code === SLASH && css.charCodeAt(pos + 1) === SLASH){
+					next = css.indexOf('\n', pos + 2);
+					currentToken = ['comment', css.slice(pos, next + 1), pos, next];
+					pos = next;
 				} else {
 					RE_WORD_END.lastIndex = pos + 1;
 					RE_WORD_END.test(css);


### PR DESCRIPTION
 ### GOAL
 Add a styled components linter to the `shipt/segway-next` project

### PROBLEM 
When parsing Styled components with style lint, we are essentially parsing the code with an assumed CSS-in-JS custom syntax.  In traditional CSS, double slash comments are invalid, and rather we have to use block comments in the format `/*...*/`.  While double slash comments are technically valid in the context of CSS-in-JS, the original version of this package had a more strict adherence to the CSS convention.  It's tokenizer did not classify double slash comments as `comments`, and would  run into a parsing error, throwing the following:

<img width="307" alt="Screen Shot 2023-03-27 at 1 36 29 PM" src="https://user-images.githubusercontent.com/44204742/228297248-66f9f74c-40a0-4e62-98c7-744bde2b8140.png">

This prevents the linter from parsing the remainder of the styled components, and does not present clear messaging on what is causing the error, causing a potential roadblock for our developers.

### SOLUTION

I have modified to tokenizer to classify double slash comments as `comment`, the same way we do with block comments.  We already use plenty of these in our styled components, and they are valid in the context of styled components.  This will allow us to target actually CSS rules and catch potentially breaking errors in our styled components.
